### PR TITLE
Fix/112 relationships create the same entity configuration

### DIFF
--- a/Dappi.HeadlessCms/Controllers/ModelsController.cs
+++ b/Dappi.HeadlessCms/Controllers/ModelsController.cs
@@ -526,8 +526,8 @@ namespace Dappi.HeadlessCms.Controllers
             .HasForeignKey<{modelName}>(ad => ad.{propertyName}Id);",
 
                 "onetomany" => $@"        modelBuilder.Entity<{modelName}>()
-            .HasOne<{relatedTo}>(s => s.{propertyName})
-            .WithMany(e => e.{relatedPropertyName ?? propertyName})
+            .HasMany<{relatedTo}>(s => s.{propertyName})
+            .WithOne(e => e.{relatedPropertyName ?? propertyName})
             .HasForeignKey(s => s.{propertyName}Id);",
 
                 "manytoone" => $@"        modelBuilder.Entity<{modelName}>()


### PR DESCRIPTION
Modified the class (entity) generating code to correctly generate the properties when configuring a One-To-Many relation through the frontend. Also, modified the entity configuration that is generated to match the newly updated properties.

Resolves #112 