### PR TITLE
fix: fixed circular dependency

### DIFF
--- a/Dappi.SourceGenerator/CrudGenerator.cs
+++ b/Dappi.SourceGenerator/CrudGenerator.cs
@@ -98,7 +98,7 @@ public partial class {item.ClassName}Controller(
 
 {mediaInfoIncludeCode}
 
-        var result = await dbContext.{item.ClassName}s{includesCode}
+        var result = await query
             .FirstOrDefaultAsync(p => p.Id == id);
 
         if (result is null)
@@ -224,7 +224,7 @@ public partial class {item.ClassName}Controller(
             .Where(p => p.PropertyType == typeof(MediaInfo))
             .ToList();
             
-        var query = dbContext.{model.ClassName}s.AsQueryable();
+        var query = dbContext.{model.ClassName}s.AsNoTracking().AsQueryable();
        
         query = query{includesCode};
         


### PR DESCRIPTION
Resolves #126 

Disabled the Change Tracker for GET methods because it caused the circular dependency issue. Also fixed the duplicate query initialization in the GET by ID method.

```
 var query = dbContext.Products.AsNoTracking().AsQueryable();
```

```
var result = await query
            .FirstOrDefaultAsync(p => p.Id == id);
```