### PR TITLE
fix(Dappi.Cli): Add Dappi.Core reference handling in InitCommand

### DIFF
--- a/Dappi.Cli/Commands/InitCommand.cs
+++ b/Dappi.Cli/Commands/InitCommand.cs
@@ -199,7 +199,7 @@ public class InitCommand(ILogger<InitCommand> logger) : AsyncCommand<InitCommand
             },
             {
                 @"..\..\Dappi.SourceGenerator\Dappi.SourceGenerator.csproj",
-                ("Dappi.SourceGenerator", [("Version", tagName), ("OutputItemType", "Analyzer")])
+                ("Dappi.SourceGenerator", [("Version", tagName), ("OutputItemType", "Analyzer"), ("IncludeAssets", "build; native; contentfiles; analyzers")])
             },
             {
                 @"..\..\Dappi.Core\Dappi.Core.csproj",


### PR DESCRIPTION
### Description

Adds handling of new `Dappi.Core` project reference in the `InitCommand` to be replaced with the Nuget package reference.


### Testing 

Trust me bro.