### PR TITLE
fix: align some of the buttons and icons

### DIFF
--- a/CCUI.DAPPI/src/app/create-enum-dialog/create-enum-dialog.component.scss
+++ b/CCUI.DAPPI/src/app/create-enum-dialog/create-enum-dialog.component.scss
@@ -11,7 +11,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 24px 24px 0 24px;
+    padding: 24px;
     border-bottom: vars.$divider;
     margin-bottom: 24px;
 
@@ -60,8 +60,6 @@
 
       .close-btn {
         color: vars.$text-secondary;
-        width: 32px;
-        height: 32px;
         border-radius: 4px;
         transition: all 0.2s ease;
 
@@ -165,8 +163,7 @@
 
           .remove-btn {
             color: vars.$error-light;
-            width: 28px;
-            height: 28px;
+            height: max-content;
             border-radius: 4px;
             transition: all 0.2s ease;
 

--- a/CCUI.DAPPI/src/app/edit-enum-dialog/edit-enum-dialog.component.scss
+++ b/CCUI.DAPPI/src/app/edit-enum-dialog/edit-enum-dialog.component.scss
@@ -11,7 +11,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 24px 24px 0 24px;
+    padding: 24px;
     border-bottom: vars.$divider;
     margin-bottom: 24px;
 
@@ -68,6 +68,13 @@
         &:hover {
           background-color: vars.$background-hover;
           color: vars.$text-primary;
+        }
+
+        mat-icon {
+              font-size: 16px;
+              width: max-content;
+              height: max-content;
+              margin-bottom: 8px;
         }
       }
     }

--- a/CCUI.DAPPI/src/app/enum-manager/enum-manager.component.scss
+++ b/CCUI.DAPPI/src/app/enum-manager/enum-manager.component.scss
@@ -209,8 +209,9 @@
 
             mat-icon {
               font-size: 16px;
-              width: 16px;
-              height: 16px;
+              width: min-content;
+              height: min-content;
+              margin-bottom: 8px;
             }
           }
         }

--- a/CCUI.DAPPI/src/app/sidebar/sidebar.component.scss
+++ b/CCUI.DAPPI/src/app/sidebar/sidebar.component.scss
@@ -90,7 +90,7 @@
     color: white;
     flex: 1;
     font-size: 14px;
-
+    width: 30%;
     &::placeholder {
       color: rgba(255, 255, 255, 0.5);
     }
@@ -127,7 +127,6 @@
   font-size: 18px;
   height: 18px;
   width: 18px;
-  margin: 0 8px;
 }
 
 .add-button-container {

--- a/CCUI.DAPPI/src/app/view-enum-code-dialog/view-enum-code-dialog.component.scss
+++ b/CCUI.DAPPI/src/app/view-enum-code-dialog/view-enum-code-dialog.component.scss
@@ -72,8 +72,9 @@
 
           mat-icon {
             font-size: 16px;
-            width: 16px;
-            height: 16px;
+            width: min-content;
+            height: min-content;
+            margin-bottom: 8px;
           }
         }
       }


### PR DESCRIPTION
**Description:**
- This PR aligns some of the icons and buttons. Changes were made only in the scss files of the corresponding components.

You can review the changes in the following screenshots:
<img width="110" height="78" alt="image" src="https://github.com/user-attachments/assets/880d2218-9a45-498a-b520-71ea67eb1586" />
<img width="110" height="67" alt="image" src="https://github.com/user-attachments/assets/b9e5aa10-36a3-44d9-aa75-002a77e44ecb" />
<img width="200" height="67" alt="image" src="https://github.com/user-attachments/assets/d415d859-c5d0-418f-a895-3c15ea165aa1" />
<img width="400" height="144" alt="image" src="https://github.com/user-attachments/assets/767a3103-d1b1-4fa1-a271-a85138eab766" />
<img width="400" height="256" alt="image" src="https://github.com/user-attachments/assets/262432ae-b098-4964-a192-d551390baff3" />
<img width="400" height="69" alt="image" src="https://github.com/user-attachments/assets/177725fb-cc52-49a9-93b1-6b56824cc4b0" />
<img width="400" height="73" alt="image" src="https://github.com/user-attachments/assets/4e793d42-9670-4b8b-aafb-d4e034a02d08" />
