### PR TITLE
Fix: Define enum for DateTime

### DIFF
--- a/CCUI.DAPPI/src/app/add-field-dialog/add-field-dialog.component.ts
+++ b/CCUI.DAPPI/src/app/add-field-dialog/add-field-dialog.component.ts
@@ -132,7 +132,7 @@ export class AddFieldDialogComponent implements OnInit, OnDestroy {
       netType: 'bool',
     },
     {
-      type: FieldTypeEnum.Date,
+      type: FieldTypeEnum.DateTime,
       icon: 'today',
       label: 'DateTime',
       description: 'For date and time values together',

--- a/CCUI.DAPPI/src/app/enums/fieldType.ts
+++ b/CCUI.DAPPI/src/app/enums/fieldType.ts
@@ -7,5 +7,6 @@ export enum FieldTypeEnum
     Relation,
     Media,
     Link,
-    Checkbox
+    Checkbox,
+    DateTime
 }


### PR DESCRIPTION
**Description:**
- This PR introduces a dedicated `DateTime` enum to address an issue where `FieldTypeEnum.Date` was used for both fields, causing both to be selected simultaneously. By separating them, each field is now handled independently.

In the following screenshot we can see the bug:
<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/44a34665-21ff-4645-8360-ddf77173208b" />

This fix resolves the issue:
<img width="600" height="350" alt="image" src="https://github.com/user-attachments/assets/2d64ca3b-664b-47e9-8f4a-b549413ae412" />

