### PR TITLE
fix: Pass stream instead of IFormFile to background queue

### DIFF
--- a/Dappi.HeadlessCms/Background/MediaUploadWorker.cs
+++ b/Dappi.HeadlessCms/Background/MediaUploadWorker.cs
@@ -2,45 +2,49 @@ using Dappi.HeadlessCms.Enums;
 using Dappi.HeadlessCms.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
-namespace Dappi.HeadlessCms.Background
+namespace Dappi.HeadlessCms.Background;
+
+public class MediaUploadWorker(
+    IMediaUploadQueue queue,
+    IServiceScopeFactory scopeFactory,
+    ILogger<MediaUploadWorker> logger)
+    : BackgroundService
 {
-    public class MediaUploadWorker(
-        IMediaUploadQueue queue,
-        IServiceScopeFactory scopeFactory)
-        : BackgroundService
+    protected override async Task ExecuteAsync(
+        CancellationToken stoppingToken)
     {
-        protected override async Task ExecuteAsync(
-            CancellationToken stoppingToken)
+        while (!stoppingToken.IsCancellationRequested)
         {
-            while (!stoppingToken.IsCancellationRequested)
+            using var scope = scopeFactory.CreateScope();
+            var uploadService = scope.ServiceProvider.GetRequiredService<IMediaUploadService>();
+            await foreach (var request in queue.GetReader().ReadAllAsync(stoppingToken))
             {
-                using var scope = scopeFactory.CreateScope();
-                var uploadService = scope.ServiceProvider.GetRequiredService<IMediaUploadService>();
-                await foreach (var request in queue.GetReader().ReadAllAsync(stoppingToken))
+                var status = MediaUploadStatus.Pending;
+                await uploadService.UpdateStatusAsync(
+                    request.MediaId,
+                    status);
+                try
                 {
-                    var status = MediaUploadStatus.Pending;
+                    logger.LogInformation("File upload started for mediaId {RequestMediaId}", request.MediaId);
+
+                    await uploadService.SaveFileAsync(
+                        request.MediaId, request.StreamAndExtensionPair);
+
+                    status = MediaUploadStatus.Completed;
+                }
+                catch(Exception ex)
+                {
+                    logger.LogError("File upload failed for mediaId {RequestMediaId}: {ExMessage}", request.MediaId, ex.Message); 
+                    status = MediaUploadStatus.Failed;
+                }
+                finally
+                {
                     await uploadService.UpdateStatusAsync(
                         request.MediaId,
                         status);
-                    try
-                    {
-                        await uploadService.SaveFileAsync(
-                            request.MediaId,
-                            request.File);
-
-                        status = MediaUploadStatus.Completed;
-                    }
-                    catch
-                    {
-                        status = MediaUploadStatus.Failed;
-                    }
-                    finally
-                    {
-                        await uploadService.UpdateStatusAsync(
-                            request.MediaId,
-                            status);
-                    }
+                    logger.LogInformation("File upload completed for mediaId {RequestMediaId}", request.MediaId);
                 }
             }
         }

--- a/Dappi.HeadlessCms/Core/Requests/MediaUploadRequest.cs
+++ b/Dappi.HeadlessCms/Core/Requests/MediaUploadRequest.cs
@@ -8,6 +8,17 @@ namespace Dappi.HeadlessCms.Core.Requests
     // our channel can only do one job and that is why we wrap these in a request
     public record MediaUploadRequest(
         Guid MediaId,
-        IFormFile File
+        StreamAndExtensionPair StreamAndExtensionPair
     );
+
+    public record StreamAndExtensionPair(Stream Stream, string Extension)
+    {
+        public static async Task<StreamAndExtensionPair> CreateFromFormFile(IFormFile file)
+        {
+            var memoryStream = new MemoryStream();
+            await file.CopyToAsync(memoryStream);
+            memoryStream.Position = 0;
+            return new StreamAndExtensionPair(memoryStream, Path.GetExtension(file.FileName));    
+        }
+    }
 }

--- a/Dappi.HeadlessCms/Interfaces/IMediaUploadService.cs
+++ b/Dappi.HeadlessCms/Interfaces/IMediaUploadService.cs
@@ -1,3 +1,4 @@
+using Dappi.HeadlessCms.Core.Requests;
 using Dappi.HeadlessCms.Enums;
 using Dappi.HeadlessCms.Models;
 using Microsoft.AspNetCore.Http;
@@ -9,6 +10,7 @@ namespace Dappi.HeadlessCms.Interfaces
         public void DeleteMedia(MediaInfo media);
         Task UpdateStatusAsync(Guid mediaId, MediaUploadStatus status);
         public Task SaveFileAsync(Guid mediaId, IFormFile file);
+        public Task SaveFileAsync(Guid mediaId, StreamAndExtensionPair streamAndExtensionPair);
         public void ValidateFile(IFormFile file);
     }
 }

--- a/Dappi.SourceGenerator/Generators/ActionsGenerator.cs
+++ b/Dappi.SourceGenerator/Generators/ActionsGenerator.cs
@@ -337,10 +337,9 @@ namespace Dappi.SourceGenerator.Generators
 
                                  await dbContext.Set<MediaInfo>().AddAsync(mediaInfo);
                                  await dbContext.SaveChangesAsync();
-
                                  await queue.EnqueueAsync(new MediaUploadRequest(
                                      mediaInfo.Id,
-                                     file
+                                     await StreamAndExtensionPair.CreateFromFormFile(file)
                                  ));
                                  
                                  dbContext.Entry(entity).State = EntityState.Modified;


### PR DESCRIPTION
## What Changed?

Changed passing of `IFormFile` to background service to use a `Stream`.

## Why?

Because the `IFormFile`'s stream was disposed in the context of the controller previously, we were accessing a disposed object in the background thread. 

Closes #291 

## Type of Change

<!-- Check the box that applies by putting an 'x' inside the brackets: [x]. Delete the other unselected options. -->

- [x] 🐛 Bug fix (fixes an issue without breaking existing functionality)

## How Did You Test This?
By manually testing uploads. First confirm the failure then fix it.

**What I tested:**

- [Uploading from the UI]

**How to test it:**

<!-- Optional: Add steps for reviewers to reproduce your testing -->
Just upload a damn picture

## Review Checklist

<!-- Quick self-check before submitting. You don't need to check every box, but consider each item. -->

- [x] My code follows the project's style and conventions
- [x] I've reviewed my own code for obvious issues
- [ ] I've added comments where the code might be confusing
- [ ] I've updated relevant documentation (if needed)
- [x] I've tested my changes and they work as expected

## Screenshots / Additional Context

<!-- Optional: Add screenshots, logs, or any other helpful information for reviewers -->
