### PR TITLE
feat: add FileName to StreamAndExtensionPair and overload SaveFileAsync for IFormFile

### DIFF
--- a/Dappi.HeadlessCms/Core/Requests/MediaUploadRequest.cs
+++ b/Dappi.HeadlessCms/Core/Requests/MediaUploadRequest.cs
@@ -6,19 +6,20 @@ namespace Dappi.HeadlessCms.Core.Requests
     // this is a channel payload
     // in our UploadMediaAsync we have the id of the entity, the file, and we return mediaInfo
     // our channel can only do one job and that is why we wrap these in a request
-    public record MediaUploadRequest(
-        Guid MediaId,
-        StreamAndExtensionPair StreamAndExtensionPair
-    );
+    public record MediaUploadRequest(Guid MediaId, StreamAndExtensionPair StreamAndExtensionPair);
 
-    public record StreamAndExtensionPair(Stream Stream, string Extension)
+    public record StreamAndExtensionPair(Stream Stream, string Extension, string FileName)
     {
         public static async Task<StreamAndExtensionPair> CreateFromFormFile(IFormFile file)
         {
             var memoryStream = new MemoryStream();
             await file.CopyToAsync(memoryStream);
             memoryStream.Position = 0;
-            return new StreamAndExtensionPair(memoryStream, Path.GetExtension(file.FileName));    
+
+            var extension = Path.GetExtension(file.FileName);
+            var fileName = Path.GetFileName(file.FileName);
+
+            return new StreamAndExtensionPair(memoryStream, extension, fileName);
         }
     }
 }

--- a/Dappi.HeadlessCms/Interfaces/IMediaUploadService.cs
+++ b/Dappi.HeadlessCms/Interfaces/IMediaUploadService.cs
@@ -9,7 +9,8 @@ namespace Dappi.HeadlessCms.Interfaces
     {
         public void DeleteMedia(MediaInfo media);
         Task UpdateStatusAsync(Guid mediaId, MediaUploadStatus status);
-        public Task SaveFileAsync(Guid mediaId, StreamAndExtensionPair streamAndExtensionPair);
+        Task SaveFileAsync(Guid mediaId, StreamAndExtensionPair streamAndExtensionPair);
+        Task SaveFileAsync(Guid mediaId, IFormFile file);
         public void ValidateFile(IFormFile file);
     }
 }

--- a/Dappi.HeadlessCms/Services/StorageServices/AwsS3StorageService.cs
+++ b/Dappi.HeadlessCms/Services/StorageServices/AwsS3StorageService.cs
@@ -18,6 +18,16 @@ namespace Dappi.HeadlessCms.Services.StorageServices
             // TODO: implement deletion of objects on s3
         }
 
+        public async Task SaveFileAsync(Guid mediaId, IFormFile file)
+        {
+            if (file == null || file.Length == 0)
+                throw new Exception("No file was uploaded.");
+
+            var pair = await StreamAndExtensionPair.CreateFromFormFile(file);
+
+            await SaveFileAsync(mediaId, pair);
+        }
+
         public async Task SaveFileAsync(Guid mediaId, StreamAndExtensionPair streamAndExtensionPair)
         {
             var accessKey = configuration["AWS:Account:AccessKey"];
@@ -57,7 +67,7 @@ namespace Dappi.HeadlessCms.Services.StorageServices
                     Key = objectKey,
                     InputStream = streamAndExtensionPair.Stream,
                     AutoCloseStream = true,
-                    ContentType = GetContentType(streamAndExtensionPair.Extension),
+                    ContentType = GetContentType(extension),
                 };
 
                 await client.PutObjectAsync(putRequest);
@@ -100,8 +110,7 @@ namespace Dappi.HeadlessCms.Services.StorageServices
         {
             var media = await dbContext
                 .DbContext.Set<MediaInfo>()
-                .Where(m => m.Id == mediaId)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(m => m.Id == mediaId);
 
             if (media == null)
                 return;


### PR DESCRIPTION
## What Changed?

- Added a `FileName` property to `StreamAndExtensionPair` to preserve the original file name of uploaded files.  
- Updated `StreamAndExtensionPair.CreateFromFormFile` to populate `FileName`.  
- Added `SaveFileAsync(Guid mediaId, IFormFile file)` overload in `AwsS3StorageService` to handle `IFormFile` uploads by delegating to the main `StreamAndExtensionPair` method.  

## Why?

- To preserve the original file name for storage, logging, or S3 usage.  
- To make uploads consistent between `IFormFile` and `StreamAndExtensionPair`.  

## Type of Change

-  ✨ New feature (adds new functionality without breaking existing features)  

## How Did You Test This?

**What I tested:**  
- Uploaded files using both `IFormFile` and `StreamAndExtensionPair` paths.  
- Verified that S3 object URLs are correctly generated.  
- Verified that the original file name is correctly captured in `StreamAndExtensionPair`.  

**How to test it:**  
1. Upload a file via API using `IFormFile`.  
2. Confirm `StreamAndExtensionPair.FileName` matches the uploaded file name.  

## Review Checklist

- [x] My code follows the project's style and conventions
- [x] I've reviewed my own code for obvious issues
- [ ] I've added comments where the code might be confusing
- [ ] I've updated relevant documentation (if needed)
- [x] I've tested my changes and they work as expected