### PR TITLE
fix: making the name of the Dappi generated filter unique for every GetAll endpoint

### DIFF
--- a/Dappi.Core/Utils/CamelCaseConverter.cs
+++ b/Dappi.Core/Utils/CamelCaseConverter.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Dappi.Core.Utils
+{
+    public static class CamelCaseConverter
+    {
+        public static string ToCamelCase(this string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return text;
+            }
+
+            var parts = Regex.Split(text.Trim(), @"[\s_\-]+");
+
+            if (parts.Length == 0)
+            {
+                return text;
+            }
+
+            var sb = new StringBuilder();
+
+            for (int i = 0; i < parts.Length; i++)
+            {
+                var part = parts[i];
+
+                if (string.IsNullOrWhiteSpace(part))
+                {
+                    continue;
+                }
+
+                sb.Append(i == 0 ? ToLowerFirst(part) : ToUpperFirst(part));
+            }
+
+            return sb.ToString();
+        }
+
+        private static string ToLowerFirst(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            if (value.Length == 1)
+            {
+                return value.ToLowerInvariant();
+            }
+
+            return char.ToLowerInvariant(value[0]) + value.Substring(1);
+        }
+
+        private static string ToUpperFirst(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            if (value.Length == 1)
+            {
+                return value.ToUpperInvariant();
+            }
+
+            return char.ToUpperInvariant(value[0]) + value.Substring(1).ToLowerInvariant();
+        }
+    }
+}

--- a/Dappi.SourceGenerator/Generators/ActionsGenerator.cs
+++ b/Dappi.SourceGenerator/Generators/ActionsGenerator.cs
@@ -103,7 +103,7 @@ namespace Dappi.SourceGenerator.Generators
                 {{PropagateDappiAuthorizationTags(item.AuthorizeAttributes, AuthorizeMethods.Get)}}
                 [CollectionFilter]
                 [IncludeQueryFilter]
-                public async Task<IActionResult> Get{{item.ClassName.Pluralize()}}([FromQuery] {{item.ClassName}}Filter? {{item.ClassName}}Filter, [FromQuery] string? fields = null)
+                public async Task<IActionResult> Get{{item.ClassName.Pluralize()}}([FromQuery] {{item.ClassName}}Filter? {{item.ClassName.ToCamelCase()}}Filter, [FromQuery] string? fields = null)
                 {
                     try
                     {
@@ -114,13 +114,13 @@ namespace Dappi.SourceGenerator.Generators
                         var filters = HttpContext.Items[CollectionFilter.FilterParamsKey] as List<Filter>;
                         if (filters is not null && filters.Count > 0)
                         {
-                            query = LinqExtensions.ApplyFiltering(query, {{item.ClassName}}Filter);
+                            query = LinqExtensions.ApplyFiltering(query, {{item.ClassName.ToCamelCase()}}Filter);
                             query = query.ApplyFilter(filters);
                         }
 
-                        if (!string.IsNullOrEmpty({{item.ClassName}}Filter.SortBy))
+                        if (!string.IsNullOrEmpty({{item.ClassName.ToCamelCase()}}Filter.SortBy))
                         {
-                            query = LinqExtensions.ApplySorting(query, {{item.ClassName}}Filter.SortBy, {{item.ClassName}}Filter.SortDirection);
+                            query = LinqExtensions.ApplySorting(query, {{item.ClassName.ToCamelCase()}}Filter.SortBy, {{item.ClassName.ToCamelCase()}}Filter.SortDirection);
                         }
 
                         var total = await query.CountAsync();
@@ -130,15 +130,15 @@ namespace Dappi.SourceGenerator.Generators
                         if (selectExpression is null)
                         {
                             var data = await query
-                                .Skip({{item.ClassName}}Filter.Offset)
-                                .Take({{item.ClassName}}Filter.Limit)
+                                .Skip({{item.ClassName.ToCamelCase()}}Filter.Offset)
+                                .Take({{item.ClassName.ToCamelCase()}}Filter.Limit)
                                 .ToListAsync();
 
                             var listDto = new ListResponseDTO<{{item.ClassName}}>
                             {
                                 Data = data,
-                                Limit = {{item.ClassName}}Filter.Limit,
-                                Offset = {{item.ClassName}}Filter.Offset,
+                                Limit = {{item.ClassName.ToCamelCase()}}Filter.Limit,
+                                Offset = {{item.ClassName.ToCamelCase()}}Filter.Offset,
                                 Total = total
                             };
 
@@ -146,16 +146,16 @@ namespace Dappi.SourceGenerator.Generators
                         }
 
                         var shapedData = await query
-                            .Skip({{item.ClassName}}Filter.Offset)
-                            .Take({{item.ClassName}}Filter.Limit)
+                            .Skip({{item.ClassName.ToCamelCase()}}Filter.Offset)
+                            .Take({{item.ClassName.ToCamelCase()}}Filter.Limit)
                             .Select(selectExpression)
                             .ToDynamicListAsync();
 
                         var shapedListDto = new ListResponseDTO<object>
                         {
                             Data = shapedData,
-                            Limit = {{item.ClassName}}Filter.Limit,
-                            Offset = {{item.ClassName}}Filter.Offset,
+                            Limit = {{item.ClassName.ToCamelCase()}}Filter.Limit,
+                            Offset = {{item.ClassName.ToCamelCase()}}Filter.Offset,
                             Total = total
                         };
 


### PR DESCRIPTION
## What Changed?

- Updated generated `Get{EntityPlural}` endpoint signature to avoid query model-binding prefix collisions by renaming the filter parameter:
  - From: `([FromQuery] {Item}Filter? filter, ...)`
  - To: `([FromQuery] {Item}Filter? {{item.ClassName}}Filter, ...)` (example: `GetAssets([FromQuery] AssetFilter? AssetFilter, ...)`)

## Why?

Requests that combined pagination (`limit`, `offset`) with collection filtering (`filter[...]`) were silently falling back to default pagination values. This was caused by an ASP.NET Core model-binding prefix collision when the action parameter name matched the `filter[...]` prefix. Renaming the parameter eliminates the collision and keeps pagination working alongside `filter[...]` filters.

## Type of Change

-  🐛 Bug fix (fixes an issue without breaking existing functionality)

## How Did You Test This?

**What I tested:**

- `GET /api/{entity}?limit=5` returns `Limit = 5`
- `GET /api/{entity}?limit=5&filter[Id][$eq]=...` returns `Limit = 5` (not defaulting back to 10)

**How to test it:**

1. Run the API.
2. Call `GET /api/{entity}?limit=5` and verify the response page size is 5.
3. Call `GET /api/{entity}?limit=5&filter[Id][$eq]=<guid>` and verify the response page size is still 5.

## Review Checklist

- [x] My code follows the project's style and conventions
- [x] I've reviewed my own code for obvious issues
- [ ] I've added comments where the code might be confusing
- [ ] I've updated relevant documentation (if needed)
- [x] I've tested my changes and they work as expected