### PR TITLE
feat: add AdminGuard to protect admin routes

### DIFF
--- a/CCUI.DAPPI/src/app/app.routes.ts
+++ b/CCUI.DAPPI/src/app/app.routes.ts
@@ -9,6 +9,7 @@ import { AuthComponent } from './auth/auth.component';
 import { AuthGuard } from './services/auth/auth.guard';
 import { NonAuthGuard } from './services/auth/non-auth.guard';
 import { SettingsComponent } from './settings/settings.component';
+import { AdminGuard } from './services/auth/admin.guard';
 
 export const routes: Routes = [
   { path: '', redirectTo: '/home', pathMatch: 'full' },
@@ -18,7 +19,7 @@ export const routes: Routes = [
   { path: 'content-create', component: NewEntryComponent, canActivate: [AuthGuard] },
   { path: 'schema-importer', component: SchemaImporterComponent, canActivate: [AuthGuard] },
   { path: 'enum-manager', component: EnumManagerComponent, canActivate: [AuthGuard] },
-  { path: 'settings', component: SettingsComponent, canActivate: [AuthGuard] },
+  { path: 'settings', component: SettingsComponent, canActivate: [AuthGuard, AdminGuard] },
   { path: 'auth', component: AuthComponent, canActivate: [NonAuthGuard] },
   { path: '**', redirectTo: '/home' },
 ];

--- a/CCUI.DAPPI/src/app/services/auth/admin.guard.ts
+++ b/CCUI.DAPPI/src/app/services/auth/admin.guard.ts
@@ -1,0 +1,32 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { Observable, combineLatest, map, take } from 'rxjs';
+import { selectIsAuthenticated, selectUser } from '../../state/auth/auth.selectors';
+import * as AuthActions from '../../state/auth/auth.actions';
+
+export const AdminGuard: CanActivateFn = ():
+  | Observable<boolean | UrlTree>
+  | Promise<boolean | UrlTree>
+  | boolean
+  | UrlTree => {
+  const store = inject(Store);
+  const router = inject(Router);
+
+  store.dispatch(AuthActions.checkAuth());
+
+  return combineLatest([store.select(selectIsAuthenticated), store.select(selectUser)]).pipe(
+    take(1),
+    map(([isAuthenticated, user]) => {
+      if (!isAuthenticated) {
+        return router.createUrlTree(['/auth']);
+      }
+
+      if (user?.roles.includes('Admin')) {
+        return true;
+      }
+
+      return router.createUrlTree(['/home']);
+    })
+  );
+};


### PR DESCRIPTION
## What Changed?

Added AdminGuard to protect admin routes

## Why?

To restrict access to admin-only routes.

## Type of Change

<!-- Check the box that applies by putting an 'x' inside the brackets: [x]. Delete the other unselected options. -->

- [x] ✨ New feature (adds new functionality without breaking existing features)

## Review Checklist

<!-- Quick self-check before submitting. You don't need to check every box, but consider each item. -->

- [x] My code follows the project's style and conventions
- [x] I've reviewed my own code for obvious issues
- [x] I've tested my changes and they work as expected