### PR TITLE
fix: prevent [Object object] from appearing in modal by extracting a proper error message

### DIFF
--- a/CCUI.DAPPI/src/app/create-enum-dialog/create-enum-dialog.component.ts
+++ b/CCUI.DAPPI/src/app/create-enum-dialog/create-enum-dialog.component.ts
@@ -8,6 +8,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { EnumManagementService } from '../services/common/enum-management.service';
+import { extractErrorMessage } from '../utils/utilFunctions';
 
 @Component({
   selector: 'app-create-enum-dialog',
@@ -97,7 +98,7 @@ export class CreateEnumDialogComponent implements OnInit {
       },
       error: (error) => {
         console.error('Failed to create enum:', error);
-        const errorMessage = error.error?.message || 'Failed to create enum';
+        const errorMessage = extractErrorMessage(error, 'Failed to create enum');
         this.snackBar.open(errorMessage, 'Close', { duration: 5000 });
       },
     });

--- a/CCUI.DAPPI/src/app/edit-enum-dialog/edit-enum-dialog.component.ts
+++ b/CCUI.DAPPI/src/app/edit-enum-dialog/edit-enum-dialog.component.ts
@@ -8,6 +8,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { EnumManagementService } from '../services/common/enum-management.service';
+import { extractErrorMessage } from '../utils/utilFunctions';
 
 interface EnumDisplayData {
   name: string;
@@ -114,7 +115,7 @@ export class EditEnumDialogComponent implements OnInit {
       },
       error: (error) => {
         console.error('Failed to update enum:', error);
-        const errorMessage = error.error?.message || 'Failed to update enum';
+        const errorMessage = extractErrorMessage(error, 'Failed to update enum');
         this.snackBar.open(errorMessage, 'Close', { duration: 5000 });
       },
     });

--- a/CCUI.DAPPI/src/app/services/auth/auth.service.ts
+++ b/CCUI.DAPPI/src/app/services/auth/auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable, catchError, throwError } from 'rxjs';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { BASE_API_URL } from '../../../Constants';
+import { extractErrorMessage } from '../../utils/utilFunctions';
 
 export interface LoginRequest {
   username: string;
@@ -51,19 +52,9 @@ export class AuthService {
       if (error.status === 401) {
         errorMessage = 'Invalid username or password';
       } else if (error.status === 400) {
-        if (error.error && typeof error.error === 'object') {
-          const validationErrors = [];
-          for (const key in error.error) {
-            if (error.error.hasOwnProperty(key)) {
-              validationErrors.push(error.error[key]);
-            }
-          }
-          errorMessage = validationErrors.map((e) => e.description).join(' ');
-        } else {
-          errorMessage = error.error?.message || 'Bad request';
-        }
+        errorMessage = extractErrorMessage(error, 'Bad request');
       } else {
-        errorMessage = `Error Code: ${error.status}, Message: ${error.error?.message || error.message}`;
+        errorMessage = `Error Code: ${error.status}, Message: ${extractErrorMessage(error, error.message)}`;
       }
     }
 

--- a/CCUI.DAPPI/src/app/state/collection/collection.effects.ts
+++ b/CCUI.DAPPI/src/app/state/collection/collection.effects.ts
@@ -18,6 +18,7 @@ import { selectSelectedType } from '../content/content.selectors';
 import * as ContentActions from '../content/content.actions';
 import { BASE_API_URL } from '../../../Constants';
 import { ModelField, FieldType, ModelResponse, CrudActions } from '../../models/content.model';
+import { extractErrorMessage } from '../../utils/utilFunctions';
 
 @Injectable()
 export class CollectionEffects {
@@ -38,7 +39,7 @@ export class CollectionEffects {
             });
           }),
           catchError((error) => {
-            this.showErrorPopup(`Failed to load collection types: ${error.error}`);
+            this.showErrorPopup(`Failed to load collection types: ${extractErrorMessage(error)}`);
             return of(
               CollectionActions.loadCollectionTypesFailure({
                 error: error.message,
@@ -61,7 +62,7 @@ export class CollectionEffects {
             });
           }),
           catchError((error) => {
-            this.showErrorPopup(`Failed to load draft collection types: ${error.error}`);
+            this.showErrorPopup(`Failed to load draft collection types: ${extractErrorMessage(error)}`);
             return of(
               CollectionActions.loadDraftCollectionTypesFailure({
                 error: error.message,
@@ -84,7 +85,7 @@ export class CollectionEffects {
             });
           }),
           catchError((error) => {
-            this.showErrorPopup(`Failed to load published collection types: ${error.error}`);
+            this.showErrorPopup(`Failed to load published collection types: ${extractErrorMessage(error)}`);
             return of(
               CollectionActions.loadPublishedCollectionTypesFailure({
                 error: error.message,
@@ -149,13 +150,13 @@ export class CollectionEffects {
                 });
               }),
               catchError((error) => {
-                this.showErrorPopup(`Failed to load fields: ${error.error}`);
+                this.showErrorPopup(`Failed to load fields: ${extractErrorMessage(error)}`);
                 return of(CollectionActions.loadFieldsFailure({ error: error.message }));
               })
             );
           }),
           catchError((error) => {
-            this.showErrorPopup(`Failed to load enums: ${error.error}`);
+            this.showErrorPopup(`Failed to load enums: ${extractErrorMessage(error)}`);
             return of(CollectionActions.loadFieldsFailure({ error: error.message }));
           })
         );
@@ -189,7 +190,7 @@ export class CollectionEffects {
               console.log('Backend is restarting. This is expected behavior.');
               return of(CollectionActions.saveContentSuccess({ restarting: true }));
             }
-            this.showErrorPopup(`Failed to save content: ${error.error}`);
+            this.showErrorPopup(`Failed to save content: ${extractErrorMessage(error)}`);
             console.error('Error saving content:', error);
             return of(CollectionActions.saveContentFailure({ error }));
           })
@@ -211,7 +212,7 @@ export class CollectionEffects {
           ),
           catchError((error) => {
             console.error('Error creating model:', error);
-            this.showErrorPopup(`Failed to create model: ${error.error}`);
+            this.showErrorPopup(`Failed to create model: ${extractErrorMessage(error)}`);
             return of(CollectionActions.addCollectionTypeFailure({ error }));
           })
         );
@@ -262,7 +263,7 @@ export class CollectionEffects {
             })
           ),
           catchError((error) => {
-            this.showErrorPopup(`Failed to add field: ${error.error}`);
+            this.showErrorPopup(`Failed to add field: ${extractErrorMessage(error)}`);
             return of(CollectionActions.addFieldFailure({ error: error.message }));
           })
         );
@@ -297,7 +298,7 @@ export class CollectionEffects {
             })
           ),
           catchError((error) => {
-            this.showErrorPopup(`Failed to update field: ${error.error}`);
+            this.showErrorPopup(`Failed to update field: ${extractErrorMessage(error)}`);
             return of(CollectionActions.updateFieldFailure({ error: error.message }));
           })
         );
@@ -317,7 +318,7 @@ export class CollectionEffects {
             return CollectionActions.deleteFieldSuccess({ fieldName: action.fieldName });
           }),
           catchError((error) => {
-            this.showErrorPopup(`Failed to delete field: ${error.error}`);
+            this.showErrorPopup(`Failed to delete field: ${extractErrorMessage(error)}`);
             return of(CollectionActions.deleteFieldFailure({ error: error.message }));
           })
         );
@@ -367,7 +368,7 @@ export class CollectionEffects {
           ),
           catchError((error) => {
             console.error('Error creating model:', error);
-            this.showErrorPopup(`Failed to configure actions: ${error.error}`);
+            this.showErrorPopup(`Failed to configure actions: ${extractErrorMessage(error)}`);
             return of(CollectionActions.configureActionsFailure({ error }));
           })
         );

--- a/CCUI.DAPPI/src/app/state/content/content.effects.ts
+++ b/CCUI.DAPPI/src/app/state/content/content.effects.ts
@@ -11,6 +11,7 @@ import { FieldType, ModelField, ModelResponse, PaginatedResponse } from '../../m
 import { BASE_API_URL } from '../../../Constants';
 import { MediaInfo, MediaUploadStatus } from '../../models/media-info.model';
 import { RecentContent } from '../../models/recent-content';
+import { extractErrorMessage } from '../../utils/utilFunctions';
 
 @Injectable({
   providedIn: 'root',
@@ -58,7 +59,7 @@ export class ContentEffects {
             })
           ),
           catchError((error) => {
-            this.showErrorPopup(`Failed to load content: ${error.error}`);
+            this.showErrorPopup(`Failed to load content: ${extractErrorMessage(error)}`);
             return of(ContentActions.loadContentFailure({ error: error.message }));
           })
         );
@@ -82,7 +83,7 @@ export class ContentEffects {
             })
           ),
           catchError((error) => {
-            this.showErrorPopup(`Failed to load related items: ${error.error}`);
+            this.showErrorPopup(`Failed to load related items: ${extractErrorMessage(error)}`);
             return of(ContentActions.loadRelatedItemsFailure({ error: error.message }));
           })
         );
@@ -135,7 +136,7 @@ export class ContentEffects {
             );
           }),
           catchError((error) => {
-            this.showErrorPopup(`Failed to load headers: ${error.error}`);
+            this.showErrorPopup(`Failed to load headers: ${extractErrorMessage(error)}`);
             return of(ContentActions.loadHeadersFailure({ error: error.message }));
           })
         );
@@ -154,7 +155,7 @@ export class ContentEffects {
         return this.http.delete(endpoint).pipe(
           map(() => ContentActions.deleteContentSuccess({ id: action.id })),
           catchError((error) => {
-            this.showErrorPopup(`Failed to delete content: ${error.error}`);
+            this.showErrorPopup(`Failed to delete content: ${extractErrorMessage(error)}`);
             return of(ContentActions.deleteContentFailure({ error: error.message }));
           })
         );
@@ -177,7 +178,7 @@ export class ContentEffects {
         return Promise.all(deletePromises)
           .then(() => ContentActions.deleteMultipleContentSuccess({ ids: action.ids }))
           .catch((error) => {
-            this.showErrorPopup(`Failed to delete multiple content: ${error.error}`);
+            this.showErrorPopup(`Failed to delete multiple content: ${extractErrorMessage(error)}`);
             return ContentActions.deleteMultipleContentFailure({
               error: error.message,
             });
@@ -226,7 +227,7 @@ export class ContentEffects {
               });
             }),
             catchError((error) => {
-              this.showErrorPopup(`Failed to create content: ${error.error}`);
+              this.showErrorPopup(`Failed to create content: ${extractErrorMessage(error)}`);
               return of(ContentActions.createContentFailure({ error: error.message }));
             })
           );
@@ -263,7 +264,7 @@ export class ContentEffects {
             });
           }),
           catchError((error) => {
-            this.showErrorPopup(`Failed to upload file: ${error.error}`);
+            this.showErrorPopup(`Failed to upload file: ${extractErrorMessage(error)}`);
             return of(ContentActions.uploadFileFailure({ error: error.message }));
           })
         );
@@ -284,7 +285,7 @@ export class ContentEffects {
             })
           ),
           catchError((error) => {
-            this.showErrorPopup(`Failed to load content type changes: ${error.error}`);
+            this.showErrorPopup(`Failed to load content type changes: ${extractErrorMessage(error)}`);
             return of(ContentActions.loadContentTypeChangesFailure({ error: error.message }));
           })
         );
@@ -318,7 +319,7 @@ export class ContentEffects {
               });
             }),
             catchError((error) => {
-              this.showErrorPopup(`Failed to update content: ${error.error}`);
+              this.showErrorPopup(`Failed to update content: ${extractErrorMessage(error)}`);
               return of(ContentActions.updateContentFailure({ error: error.message }));
             })
           );

--- a/CCUI.DAPPI/src/app/utils/utilFunctions.ts
+++ b/CCUI.DAPPI/src/app/utils/utilFunctions.ts
@@ -21,3 +21,15 @@ export function parseEnumFromNumberArray<T extends Record<number,string>>(enumOb
     }
     return kvp;
 }
+
+export function extractErrorMessage(error: any, fallback = 'Unknown error'): string {
+
+    const payload = error?.error;
+
+    if (typeof payload === 'string' && payload.trim()) return payload;
+    if (typeof payload?.message === 'string' && payload.message.trim()) return payload.message;
+    if (typeof payload?.title === 'string' && payload.title.trim()) return payload.title;
+    if (typeof error?.message === 'string' && error.message.trim()) return error.message;
+
+    return payload ? JSON.stringify(payload) : fallback;
+}


### PR DESCRIPTION
## What Changed?

Replaced inline error handling with the extractErrorMessage utility to consistently extract and display readable error message.

## Why?

<!-- Explain why these changes were needed. What problem does this solve? Link any related issues. -->

The previous implementation sometimes displayed [Object object] when the API returned a structured error response.

## Type of Change

<!-- Check the box that applies by putting an 'x' inside the brackets: [x]. Delete the other unselected options. -->

- [x] 🐛 Bug fix (fixes an issue without breaking existing functionality)

## Review Checklist

<!-- Quick self-check before submitting. You don't need to check every box, but consider each item. -->

- [x] My code follows the project's style and conventions
- [x] I've reviewed my own code for obvious issues
- [ ] I've added comments where the code might be confusing
- [ ] I've updated relevant documentation (if needed)
- [x] I've tested my changes and they work as expected

## Screenshots / Additional Context

<!-- Optional: Add screenshots, logs, or any other helpful information for reviewers -->

<img width="560" height="44" alt="image" src="https://github.com/user-attachments/assets/0a2194c8-a256-4f11-9179-78ae276259ca" />