### PR TITLE
fix: remove unused CdkAriaLive import from ContentTableComponent

### DIFF
--- a/CCUI.DAPPI/src/app/content-table/content-table.component.ts
+++ b/CCUI.DAPPI/src/app/content-table/content-table.component.ts
@@ -33,7 +33,6 @@ import { DrawerComponent } from '../relation-drawer/drawer.component';
 import { ImageViewerComponent } from '../image-viewer/image-viewer.component';
 import { selectAllowedCrudActions } from '../state/collection/collection.selectors';
 import { MediaUploadStatus } from '../models/media-info.model';
-import { CdkAriaLive } from "../../../node_modules/@angular/cdk/a11y-module.d";
 
 @Component({
   selector: 'app-content-table',
@@ -48,8 +47,7 @@ import { CdkAriaLive } from "../../../node_modules/@angular/cdk/a11y-module.d";
     MatTableModule,
     MenuComponent,
     DrawerComponent,
-    ImageViewerComponent,
-    CdkAriaLive
+    ImageViewerComponent
 ],
   templateUrl: './content-table.component.html',
   styleUrl: './content-table.component.scss',


### PR DESCRIPTION
## What Changed?

Remove unused CdkAriaLive import from ContentTableComponent

## Type of Change

<!-- Check the box that applies by putting an 'x' inside the brackets: [x]. Delete the other unselected options. -->

- [x] 🐛 Bug fix (fixes an issue without breaking existing functionality)

<!-- Quick self-check before submitting. You don't need to check every box, but consider each item. -->

- [x] My code follows the project's style and conventions
- [x] I've reviewed my own code for obvious issues
- [ ] I've added comments where the code might be confusing
- [ ] I've updated relevant documentation (if needed)
- [x] I've tested my changes and they work as expected