### PR TITLE
ci: Update release.yml and add build and pack jobs for UsersAndPermissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,10 @@ jobs:
           dotnet nuget push ./nupkgs/*.nupkg \
           --source "https://api.nuget.org/v3/index.json" \
           --api-key ${{ secrets.NUGET_API_KEY }}
+
+      - name: Build UsersAndPermissions
+        run: dotnet build Dappi.HeadlessCms.UsersAndPermissions --configuration Release /p:Version=${{ env.VERSION }} --no-restore
+
+      - name: Pack UsersAndPermissions
+        run: dotnet pack Dappi.HeadlessCms.UsersAndPermissions --configuration Release /p:Version=${{ env.VERSION }} --no-build --output nupkgs
+


### PR DESCRIPTION
## What Changed?

Added build and packaging steps for the Dappi.HeadlessCms.UsersAndPermissions project to the release workflow.
This includes:

- Building the UsersAndPermissions project
- Packing it into a NuGet package
- Including it in the existing publish pipeline alongside the other projects

## Why?

The UsersAndPermissions project was not previously included in the CI/CD pipeline, meaning it wasn’t being versioned or published with releases. This change ensures it is packaged and published consistently with the rest of the solution.

## Type of Change

-  🐛 Bug fix

## How Did You Test This?

**What I tested:**  
- UsersAndPermissions package is generated in the nupkgs folder
-  Workflow runs successfully with the new project included

**How to test it:**  
1. Trigger the workflow via a release 
2. Verify the build step for Dappi.HeadlessCms.UsersAndPermissions completes successfully
3. Confirm it is published to NuGet along with the other packages

## Review Checklist

- [x] My code follows the project's style and conventions
- [x] I've reviewed my own code for obvious issues
- [ ] I've added comments where the code might be confusing
- [ ] I've updated relevant documentation (if needed)
- [x] I've tested my changes and they work as expected