### PR TITLE
feat: add supported extensions in appsettings

### DIFF
--- a/Dappi.HeadlessCms/Interfaces/IMediaUploadService.cs
+++ b/Dappi.HeadlessCms/Interfaces/IMediaUploadService.cs
@@ -11,6 +11,5 @@ namespace Dappi.HeadlessCms.Interfaces
         Task UpdateStatusAsync(Guid mediaId, MediaUploadStatus status);
         Task SaveFileAsync(Guid mediaId, StreamAndExtensionPair streamAndExtensionPair);
         Task SaveFileAsync(Guid mediaId, IFormFile file);
-        public void ValidateFile(IFormFile file);
     }
 }

--- a/Dappi.HeadlessCms/Models/AwsStorageOptions.cs
+++ b/Dappi.HeadlessCms/Models/AwsStorageOptions.cs
@@ -4,7 +4,6 @@ public class AwsStorageOptions
 {
     public const string AwsStorage = "AWS:Storage";
     public string? BucketName { get; set; }
-    public bool? UseCdn { get; set; }
     public string? CdnUrl { get; set; }
     public List<string>? SupportedExtensions { get; set; }
 }

--- a/Dappi.HeadlessCms/Models/AwsStorageOptions.cs
+++ b/Dappi.HeadlessCms/Models/AwsStorageOptions.cs
@@ -4,4 +4,7 @@ public class AwsStorageOptions
 {
     public const string AwsStorage = "AWS:Storage";
     public string? BucketName { get; set; }
+    public bool? UseCdn { get; set; }
+    public string? CdnUrl { get; set; }
+    public List<string>? SupportedExtensions { get; set; }
 }

--- a/Dappi.HeadlessCms/Services/StorageServices/AwsS3StorageService.cs
+++ b/Dappi.HeadlessCms/Services/StorageServices/AwsS3StorageService.cs
@@ -88,17 +88,6 @@ namespace Dappi.HeadlessCms.Services.StorageServices
             }
         }
 
-        public void ValidateFile(IFormFile file)
-        {
-            if (file == null || file.Length == 0)
-                throw new Exception("No file was uploaded.");
-
-            var fileExtension = Path.GetExtension(file.FileName);
-
-            if (!IsExtensionSupported(fileExtension))
-                throw new Exception("Unsupported media type.");
-        }
-
         public async Task UpdateStatusAsync(Guid mediaId, MediaUploadStatus status)
         {
             var media = await dbContext
@@ -120,22 +109,6 @@ namespace Dappi.HeadlessCms.Services.StorageServices
                 ".pdf" => "application/pdf",
                 _ => "application/octet-stream",
             };
-
-        private bool IsExtensionSupported(string extension)
-        {
-            if (
-                _storageOptions.SupportedExtensions is null
-                || _storageOptions.SupportedExtensions.Count == 0
-            )
-            {
-                return true;
-            }
-
-            var normalizedExtension = extension.TrimStart('.').ToLower();
-            return _storageOptions.SupportedExtensions.Any(allowed =>
-                allowed.Equals(normalizedExtension, StringComparison.CurrentCultureIgnoreCase)
-            );
-        }
 
         public override string ToString() => "aws-s3";
     }

--- a/Dappi.HeadlessCms/Services/StorageServices/AwsS3StorageService.cs
+++ b/Dappi.HeadlessCms/Services/StorageServices/AwsS3StorageService.cs
@@ -73,10 +73,9 @@ namespace Dappi.HeadlessCms.Services.StorageServices
             };
             await _s3Client.PutObjectAsync(putRequest);
 
-            var baseUrl =
-                _storageOptions.UseCdn is not null && _storageOptions.UseCdn == true
-                    ? $"{_storageOptions.CdnUrl}/{objectKey}"
-                    : $"https://{_storageOptions.BucketName}.s3.{region.SystemName}.amazonaws.com/{objectKey}";
+            var baseUrl = !string.IsNullOrEmpty(_storageOptions.CdnUrl)
+                ? $"{_storageOptions.CdnUrl}/{objectKey}"
+                : $"https://{_storageOptions.BucketName}.s3.{region.SystemName}.amazonaws.com/{objectKey}";
 
             var media = await dbContext
                 .DbContext.Set<MediaInfo>()

--- a/Dappi.HeadlessCms/Services/StorageServices/AwsS3StorageService.cs
+++ b/Dappi.HeadlessCms/Services/StorageServices/AwsS3StorageService.cs
@@ -17,20 +17,24 @@ namespace Dappi.HeadlessCms.Services.StorageServices
     ) : IMediaUploadService
     {
         private readonly IAmazonS3 _s3Client = factory.CreateClient();
+        private readonly AwsStorageOptions _storageOptions = configuration
+            .GetSection(AwsStorageOptions.AwsStorage)
+            .Get<AwsStorageOptions>()!;
+        private readonly AwsAccountOptions _accountOptions = configuration
+            .GetSection(AwsAccountOptions.AwsAccount)
+            .Get<AwsAccountOptions>()!;
 
         public void DeleteMedia(MediaInfo media)
         {
             if (string.IsNullOrEmpty(media.Url))
                 return;
 
-            var bucketName = configuration["AWS:Storage:BucketName"];
-
             var uri = new Uri(media.Url);
             var objectKey = Path.GetFileName(uri.LocalPath);
 
             var deleteRequest = new DeleteObjectRequest
             {
-                BucketName = bucketName,
+                BucketName = _storageOptions.BucketName,
                 Key = objectKey,
             };
 
@@ -49,24 +53,19 @@ namespace Dappi.HeadlessCms.Services.StorageServices
 
         public async Task SaveFileAsync(Guid mediaId, StreamAndExtensionPair streamAndExtensionPair)
         {
-            var bucketName = configuration["AWS:Storage:BucketName"];
-            var cdnUrl = configuration["AWS:Storage:CdnUrl"];
-            var regionName = configuration["AWS:Account:Region"];
-
-            var useCdn =
-                bool.TryParse(configuration["AWS:Storage:UseCdn"], out var parsed) && parsed;
-
             var extension = streamAndExtensionPair.Extension.StartsWith(".")
                 ? streamAndExtensionPair.Extension
                 : "." + streamAndExtensionPair.Extension;
 
             var objectKey = $"{mediaId}{extension}";
 
-            var region = Amazon.RegionEndpoint.GetBySystemName(regionName ?? "eu-central-1");
+            var region = Amazon.RegionEndpoint.GetBySystemName(
+                _accountOptions.Region ?? "eu-central-1"
+            );
 
             var putRequest = new PutObjectRequest
             {
-                BucketName = bucketName,
+                BucketName = _storageOptions.BucketName,
                 Key = objectKey,
                 InputStream = streamAndExtensionPair.Stream,
                 AutoCloseStream = true,
@@ -74,9 +73,10 @@ namespace Dappi.HeadlessCms.Services.StorageServices
             };
             await _s3Client.PutObjectAsync(putRequest);
 
-            var baseUrl = useCdn
-                ? $"{cdnUrl}/{objectKey}"
-                : $"https://{bucketName}.s3.{region.SystemName}.amazonaws.com/{objectKey}";
+            var baseUrl =
+                _storageOptions.UseCdn is not null && _storageOptions.UseCdn == true
+                    ? $"{_storageOptions.CdnUrl}/{objectKey}"
+                    : $"https://{_storageOptions.BucketName}.s3.{region.SystemName}.amazonaws.com/{objectKey}";
 
             var media = await dbContext
                 .DbContext.Set<MediaInfo>()
@@ -96,7 +96,7 @@ namespace Dappi.HeadlessCms.Services.StorageServices
 
             var fileExtension = Path.GetExtension(file.FileName);
 
-            if (GetContentType(fileExtension) == "unsupported")
+            if (!IsExtensionSupported(fileExtension))
                 throw new Exception("Unsupported media type.");
         }
 
@@ -121,6 +121,22 @@ namespace Dappi.HeadlessCms.Services.StorageServices
                 ".pdf" => "application/pdf",
                 _ => "application/octet-stream",
             };
+
+        private bool IsExtensionSupported(string extension)
+        {
+            if (
+                _storageOptions.SupportedExtensions is null
+                || _storageOptions.SupportedExtensions.Count == 0
+            )
+            {
+                return true;
+            }
+
+            var normalizedExtension = extension.TrimStart('.').ToLower();
+            return _storageOptions.SupportedExtensions.Any(allowed =>
+                allowed.Equals(normalizedExtension, StringComparison.CurrentCultureIgnoreCase)
+            );
+        }
 
         public override string ToString() => "aws-s3";
     }

--- a/Dappi.HeadlessCms/Services/StorageServices/LocalStorageUploadService.cs
+++ b/Dappi.HeadlessCms/Services/StorageServices/LocalStorageUploadService.cs
@@ -12,28 +12,16 @@ namespace Dappi.HeadlessCms.Services.StorageServices
     {
         public void DeleteMedia(MediaInfo media)
         {
-            if (media.Url == null) throw new ArgumentNullException(media.Url);
+            if (media.Url == null)
+                throw new ArgumentNullException(media.Url);
             var filePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", media.Url);
-            if (File.Exists(filePath)) File.Delete(filePath);
-        }
-
-        public void ValidateFile(IFormFile file)
-        {
-            if (file == null || file.Length == 0)
-                throw new Exception("No file was uploaded.");
-
-            var fileExtension = Path.GetExtension(file.FileName);
-
-            if (GetContentType(fileExtension) == "unsupported")
-                throw new Exception("Unsupported media type.");
+            if (File.Exists(filePath))
+                File.Delete(filePath);
         }
 
         public async Task SaveFileAsync(Guid mediaId, IFormFile file)
         {
-            var uploadsFolder = Path.Combine(
-                Directory.GetCurrentDirectory(),
-                "wwwroot",
-                "uploads");
+            var uploadsFolder = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "uploads");
 
             if (!Directory.Exists(uploadsFolder))
                 Directory.CreateDirectory(uploadsFolder);
@@ -49,21 +37,21 @@ namespace Dappi.HeadlessCms.Services.StorageServices
 
             var relativePath = $"uploads{Path.DirectorySeparatorChar}{fileName}";
 
-            var media = await dbContext.DbContext.Set<MediaInfo>()
-                .Where(m => m.Id == mediaId).FirstOrDefaultAsync();
+            var media = await dbContext
+                .DbContext.Set<MediaInfo>()
+                .Where(m => m.Id == mediaId)
+                .FirstOrDefaultAsync();
 
-            if (media == null) return;
+            if (media == null)
+                return;
 
             media.Url = relativePath;
             await dbContext.DbContext.SaveChangesAsync();
         }
-        
+
         public async Task SaveFileAsync(Guid mediaId, StreamAndExtensionPair streamAndExtensionPair)
         {
-            var uploadsFolder = Path.Combine(
-                Directory.GetCurrentDirectory(),
-                "wwwroot",
-                "uploads");
+            var uploadsFolder = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "uploads");
 
             if (!Directory.Exists(uploadsFolder))
                 Directory.CreateDirectory(uploadsFolder);
@@ -73,15 +61,18 @@ namespace Dappi.HeadlessCms.Services.StorageServices
 
             await using (var fileStream = new FileStream(filePath, FileMode.Create))
             {
-                await streamAndExtensionPair.Stream.CopyToAsync(fileStream); 
+                await streamAndExtensionPair.Stream.CopyToAsync(fileStream);
             }
 
             var relativePath = $"uploads{Path.DirectorySeparatorChar}{fileName}";
 
-            var media = await dbContext.DbContext.Set<MediaInfo>()
-                .Where(m => m.Id == mediaId).FirstOrDefaultAsync();
+            var media = await dbContext
+                .DbContext.Set<MediaInfo>()
+                .Where(m => m.Id == mediaId)
+                .FirstOrDefaultAsync();
 
-            if (media == null) return;
+            if (media == null)
+                return;
 
             media.Url = relativePath;
             await dbContext.DbContext.SaveChangesAsync();
@@ -89,10 +80,13 @@ namespace Dappi.HeadlessCms.Services.StorageServices
 
         public async Task UpdateStatusAsync(Guid mediaId, MediaUploadStatus status)
         {
-            var media = await dbContext.DbContext.Set<MediaInfo>()
-                .Where(m => m.Id == mediaId).FirstOrDefaultAsync();
+            var media = await dbContext
+                .DbContext.Set<MediaInfo>()
+                .Where(m => m.Id == mediaId)
+                .FirstOrDefaultAsync();
 
-            if (media == null) return;
+            if (media == null)
+                return;
 
             media.Status = status;
             await dbContext.DbContext.SaveChangesAsync();

--- a/Dappi.HeadlessCms/Validators/FileUploadRequestValidator.cs
+++ b/Dappi.HeadlessCms/Validators/FileUploadRequestValidator.cs
@@ -1,0 +1,59 @@
+using Dappi.HeadlessCms.Models;
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace Dappi.HeadlessCms.Validators
+{
+    public class FileUploadRequest
+    {
+        public IFormFile File { get; set; }
+        public string FieldName { get; set; }
+    }
+
+    public class FileUploadRequestValidator : AbstractValidator<FileUploadRequest>
+    {
+        private readonly AwsStorageOptions _storageOptions;
+
+        public FileUploadRequestValidator(IConfiguration configuration)
+        {
+            _storageOptions = configuration
+                .GetSection(AwsStorageOptions.AwsStorage)
+                .Get<AwsStorageOptions>()!;
+
+            RuleFor(x => x.File)
+                .Cascade(CascadeMode.Stop)
+                .NotNull()
+                .WithMessage("No file was uploaded.")
+                .Must(file => file.Length > 0)
+                .WithMessage("File is empty.")
+                .Must(BeASupportedExtension)
+                .WithMessage("Unsupported media type.");
+
+            RuleFor(x => x.FieldName).NotEmpty().WithMessage("Field name is required.");
+        }
+
+        private bool BeASupportedExtension(IFormFile? file)
+        {
+            if (file == null)
+                return false;
+
+            var extension = System.IO.Path.GetExtension(file.FileName);
+            if (
+                _storageOptions.SupportedExtensions is null
+                || _storageOptions.SupportedExtensions.Count == 0
+            )
+            {
+                return true;
+            }
+
+            var normalizedExtension = extension.TrimStart('.').ToLower();
+            return _storageOptions.SupportedExtensions.Any(allowed =>
+                allowed.Equals(
+                    normalizedExtension,
+                    System.StringComparison.CurrentCultureIgnoreCase
+                )
+            );
+        }
+    }
+}

--- a/Dappi.HeadlessCms/Validators/FileUploadRequestValidator.cs
+++ b/Dappi.HeadlessCms/Validators/FileUploadRequestValidator.cs
@@ -15,6 +15,50 @@ namespace Dappi.HeadlessCms.Validators
     {
         private readonly AwsStorageOptions _storageOptions;
 
+        private static readonly Dictionary<string, List<byte[]>> _fileSignatures = new()
+        {
+            {
+                "jpg",
+                new List<byte[]> { new byte[] { 0xFF, 0xD8, 0xFF } }
+            },
+            {
+                "jpeg",
+                new List<byte[]> { new byte[] { 0xFF, 0xD8, 0xFF } }
+            },
+            {
+                "png",
+                new List<byte[]> { new byte[] { 0x89, 0x50, 0x4E, 0x47 } }
+            },
+            {
+                "gif",
+                new List<byte[]> { new byte[] { 0x47, 0x49, 0x46, 0x38 } }
+            },
+            {
+                "bmp",
+                new List<byte[]> { new byte[] { 0x42, 0x4D } }
+            },
+            {
+                "pdf",
+                new List<byte[]> { new byte[] { 0x25, 0x50, 0x44, 0x46 } }
+            },
+            {
+                "doc",
+                new List<byte[]> { new byte[] { 0xD0, 0xCF, 0x11, 0xE0 } }
+            },
+            {
+                "docx",
+                new List<byte[]> { new byte[] { 0x50, 0x4B, 0x03, 0x04 } }
+            },
+            {
+                "xlsx",
+                new List<byte[]> { new byte[] { 0x50, 0x4B, 0x03, 0x04 } }
+            },
+            {
+                "txt",
+                new List<byte[]> { new byte[] { 0xEF, 0xBB, 0xBF }, new byte[] { } }
+            },
+        };
+
         public FileUploadRequestValidator(IConfiguration configuration)
         {
             _storageOptions = configuration
@@ -27,33 +71,63 @@ namespace Dappi.HeadlessCms.Validators
                 .WithMessage("No file was uploaded.")
                 .Must(file => file.Length > 0)
                 .WithMessage("File is empty.")
-                .Must(BeASupportedExtension)
+                .Must(BeAValidFile)
                 .WithMessage("Unsupported media type.");
 
             RuleFor(x => x.FieldName).NotEmpty().WithMessage("Field name is required.");
         }
 
-        private bool BeASupportedExtension(IFormFile? file)
+        private bool BeAValidFile(IFormFile? file)
         {
             if (file == null)
                 return false;
 
-            var extension = System.IO.Path.GetExtension(file.FileName);
+            if (!BeASupportedExtension(file))
+                return false;
+
+            return HasValidFileSignature(file);
+        }
+
+        private bool BeASupportedExtension(IFormFile file)
+        {
             if (
-                _storageOptions.SupportedExtensions is null
+                _storageOptions.SupportedExtensions == null
                 || _storageOptions.SupportedExtensions.Count == 0
             )
-            {
                 return true;
+
+            var extension = Path.GetExtension(file.FileName)?.TrimStart('.').ToLower();
+            if (string.IsNullOrEmpty(extension))
+                return false;
+
+            return _storageOptions.SupportedExtensions.Any(ext =>
+                ext.Equals(extension, System.StringComparison.InvariantCultureIgnoreCase)
+            );
+        }
+
+        private bool HasValidFileSignature(IFormFile file)
+        {
+            var extension = Path.GetExtension(file.FileName).TrimStart('.').ToLower();
+            if (string.IsNullOrEmpty(extension) || !_fileSignatures.ContainsKey(extension))
+                return false;
+
+            var signatures = _fileSignatures[extension];
+
+            using var stream = file.OpenReadStream();
+            foreach (var signature in signatures)
+            {
+                if (signature.Length == 0)
+                    return true;
+
+                var headerBytes = new byte[signature.Length];
+                stream.Seek(0, SeekOrigin.Begin);
+                stream.ReadExactly(headerBytes, 0, headerBytes.Length);
+
+                if (headerBytes.SequenceEqual(signature))
+                    return true;
             }
 
-            var normalizedExtension = extension.TrimStart('.').ToLower();
-            return _storageOptions.SupportedExtensions.Any(allowed =>
-                allowed.Equals(
-                    normalizedExtension,
-                    System.StringComparison.CurrentCultureIgnoreCase
-                )
-            );
+            return false;
         }
     }
 }

--- a/Dappi.SourceGenerator/Generators/ActionsGenerator.cs
+++ b/Dappi.SourceGenerator/Generators/ActionsGenerator.cs
@@ -420,14 +420,6 @@ namespace Dappi.SourceGenerator.Generators
                                 UploadDate = DateTime.UtcNow
                             };
                             
-                            try { 
-                               uploadService.ValidateFile(file);
-                            }
-                            catch(Exception ex)
-                            {
-                                return BadRequest(new {message = ex.Message});
-                            }
-                            
                             property.SetValue(entity, mediaInfo);
 
                             await dbContext.Set<MediaInfo>().AddAsync(mediaInfo);

--- a/Dappi.TestEnv/appsettings.json
+++ b/Dappi.TestEnv/appsettings.json
@@ -28,7 +28,8 @@
     "Storage": {
       "UseCdn": false,
       "CdnUrl": "",
-      "BucketName": ""
+      "BucketName": "",
+      "SupportedExtensions": ["jpg", "pdf"]
     },
     "Account": {
       "AccessKey": "",

--- a/Dappi.TestEnv/appsettings.json
+++ b/Dappi.TestEnv/appsettings.json
@@ -26,7 +26,6 @@
   },
   "AWS": {
     "Storage": {
-      "UseCdn": false,
       "CdnUrl": "",
       "BucketName": "",
       "SupportedExtensions": ["jpg", "pdf"]


### PR DESCRIPTION
## What Changed?

- This PR adds a fluent validator for `FileUploadRequest`. It check the validity of the files based on their extensions. It also checks for valid signature of the extension.

## Why?

- To improve security by preventing users from uploading files with fake extensions.
- Ensures only supported file types are accepted, reducing potential runtime errors or security risks.

Closes https://github.com/codechem/dappi/issues/261

## Type of Change

- [x] 🐛 Bug fix (fixes an issue without breaking existing functionality)


## How Did You Test This?

- Tested this by uploading files to some test collections, with Swagger.

**What I tested:**

- [ ]
- [ ]

**How to test it:**

<!-- Optional: Add steps for reviewers to reproduce your testing -->

1.
2.

## Review Checklist

<!-- Quick self-check before submitting. You don't need to check every box, but consider each item. -->

- [x] My code follows the project's style and conventions
- [x] I've reviewed my own code for obvious issues
- [ ] I've added comments where the code might be confusing
- [ ] I've updated relevant documentation (if needed)
- [x] I've tested my changes and they work as expected

## Screenshots / Additional Context

<!-- Optional: Add screenshots, logs, or any other helpful information for reviewers -->
